### PR TITLE
Added endpoints for read update and delete of teams

### DIFF
--- a/core/permissions.py
+++ b/core/permissions.py
@@ -23,3 +23,19 @@ class AllowCompleteProfile(permissions.BasePermission):
             return True
         else:
             raise exceptions.PermissionDenied("Please complete your profile!")
+
+class IsLeaderOrSuperUser(permissions.BasePermission):
+    """
+    Allows only Superusers and Creator of team to delete the team.
+    """
+    def has_permission(self, request, view):
+        if request.user and request.user.is_authenticated:
+            return True
+        else:
+            raise exceptions.NotAuthenticated("Singin is required!")
+
+    def has_object_permission(self, request, view, obj):
+        if request.user.is_superuser or request.user == obj.leader:
+            return True
+        else:
+            raise exceptions.PermissionDenied("You are not team leader")

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -6,7 +6,8 @@ from .models import Hackathon, Team
 class TeamSerializer(serializers.ModelSerializer):
     class Meta:
         model = Team
-        fields = ('team_id',)
+        exclude = ['leader', 'members']
+        depth = 1
 
 class TeamCreateSerializer(serializers.ModelSerializer):
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import  HackathonsRUDView, HackathonListCreateView, HackathonTeamView, JoinTeamView
+from .views import  HackathonsRUDView, HackathonListCreateView, HackathonTeamView, JoinTeamView, TeamView
 
 urlpatterns = [
     path('hackathons/<int:pk>/teams/', HackathonTeamView.as_view()),
     path('hackathons/', HackathonListCreateView.as_view(), name='Hackathon List/Create View'),
     path('hackathons/<int:pk>/', HackathonsRUDView.as_view(), name='Hackathon Read, Edit and Delete View'),
-    path('hackathons/<int:pk>/teams/join/<str:team_id>/', JoinTeamView.as_view())
+    path('hackathons/<int:pk>/teams/join/<str:team_id>/', JoinTeamView.as_view()),
+    path('teams/<str:team_id>/', TeamView.as_view()),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -5,8 +5,9 @@ from django.utils.decorators import method_decorator
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from .models import Hackathon, Team
+from authentication.serializers import ProfileSerializer
 from .serializers import HackathonSerializer, TeamSerializer, TeamCreateSerializer, JoinTeamSerializer
-from .permissions import HackathonPermissions, AllowCompleteProfile
+from .permissions import HackathonPermissions, AllowCompleteProfile, IsLeaderOrSuperUser
 
 class HackathonTeamView(generics.ListCreateAPIView):
     """
@@ -42,8 +43,8 @@ class HackathonTeamView(generics.ListCreateAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         team = serializer.save()
-        serializer = TeamSerializer(team)
-        return Response(serializer.data, status=status.HTTP_201_CREATED)
+        data = {"team_id": team.team_id}
+        return Response(data, status=status.HTTP_201_CREATED)
 
 class JoinTeamView(generics.GenericAPIView):
     """
@@ -112,3 +113,47 @@ class HackathonsRUDView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = HackathonSerializer
     lookup_field = 'pk'
     queryset = Hackathon.objects.all()
+
+class TeamView(generics.RetrieveUpdateDestroyAPIView):
+    """
+    API used to read, update or delete the Team objects by their team_id. Only the Super User has the permissions to delete Team objects.
+    """
+
+    def get_permissions(self):
+        if self.request.method == "GET":
+            return [permissions.IsAuthenticated()]
+        else:
+            return [permissions.IsAuthenticated(), IsLeaderOrSuperUser()]
+
+    serializer_class = TeamSerializer
+    queryset = Team.objects.all()
+    lookup_field = 'team_id'
+
+    def retrieve(self, request, *args, **kwargs):
+        instance = self.get_object()
+        leader = ProfileSerializer(instance.leader).data
+        members = ProfileSerializer(instance.members, many=True).data
+        serializer = self.get_serializer(instance)
+        data = serializer.data
+        data['leader'] = leader
+        data['members'] = members
+        return Response(data)
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        instance = self.get_object()
+        serializer = self.get_serializer(instance, data=request.data, partial=partial)
+        serializer.is_valid(raise_exception=True)
+        self.perform_update(serializer)
+        leader = ProfileSerializer(instance.leader).data
+        members = ProfileSerializer(instance.members, many=True).data
+        data = serializer.data
+        data['leader'] = leader
+        data['members'] = members
+
+        if getattr(instance, '_prefetched_objects_cache', None):
+            # If 'prefetch_related' has been applied to a queryset, we need to
+            # forcibly invalidate the prefetch cache on the instance.
+            instance._prefetched_objects_cache = {}
+
+        return Response(data)


### PR DESCRIPTION
Following endpoints have been added.
- GET teams/team_id
- PUT|PATCH|DELETE teams/team_id

put and patch now only allow updating name of team.
I am currently working on LeaveTeam endpoint, removing member by leader, and few validations like not allowing a person to create two teams with in same hackathon.