### PR TITLE
Member exit endpoint and single team participation.

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -74,6 +74,19 @@ class JoinTeamSerializer(serializers.Serializer):
             members.add(user)
 
 class HackathonSerializer(serializers.ModelSerializer):
+    def validate_end(self, end):
+        if end < timezone.now():
+            raise serializers.ValidationError('End date cannot be in past')
+        return end
+    def validate_start(self, start):
+        if start < timezone.now():
+            raise serializers.ValidationError('Start date cannot be in past')
+        return start
+    def validate(self, attrs):
+        if attrs['start'] > attrs['end']:
+            raise serializers.ValidationError('Event ends before starting')
+        return attrs
+
     class Meta:
         model = Hackathon
         fields = '__all__'

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
-from .views import  HackathonsRUDView, HackathonListCreateView, HackathonTeamView, JoinTeamView, TeamView
+from .views import  HackathonsRUDView, HackathonListCreateView, HackathonTeamView, JoinTeamView, TeamView, MemberExitView
 
 urlpatterns = [
     path('hackathons/<int:pk>/teams/', HackathonTeamView.as_view()),
     path('hackathons/', HackathonListCreateView.as_view(), name='Hackathon List/Create View'),
     path('hackathons/<int:pk>/', HackathonsRUDView.as_view(), name='Hackathon Read, Edit and Delete View'),
     path('hackathons/<int:pk>/teams/join/<str:team_id>/', JoinTeamView.as_view()),
-    path('teams/<str:team_id>/', TeamView.as_view()),
+    path('teams/<str:team_id>/', TeamView.as_view(), name='Team Read, Edit, Delete View'),
+    path('teams/<str:team_id>/member-exit/<str:username>', MemberExitView.as_view())
 ]


### PR DESCRIPTION
- Validations have been added so that a user can join/create only in one team in a event.
- Endpoint has been added for members to exit from team.
`/teams/{team_id}/member-exit/{username}`
1. Leader can remove anyone from team.
2. Member can only remove themselves.
3. Leader cannot leave the team.