### PR TITLE
Added Validation to POST /hackathons/{id}/submissions/

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -13,7 +13,7 @@ class TeamSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Team
-        fields = ('name','score','hackathon','team_id')
+        fields = ('id','name','score','hackathon','team_id')
         depth = 1
 
 class TeamCreateSerializer(serializers.ModelSerializer):

--- a/core/serializers.py
+++ b/core/serializers.py
@@ -101,6 +101,12 @@ class SubmissionsSerializer(serializers.ModelSerializer):
     class Meta:
         model = Submission
         fields = '__all__'
+
+    def validate_score(self, score):
+        if score < 0:
+            raise serializers.ValidationError("Score can't be less than 0")
+        return score
+        
 class MemberExitSerializer(serializers.Serializer):
 
     def exit_team(self):

--- a/core/views.py
+++ b/core/views.py
@@ -163,6 +163,10 @@ class HackathonSubmissionView(generics.ListCreateAPIView):
             team = Team.objects.get(members=request.user, hackathon=hackathon)
             if request.data['team'] != team.pk:
                 return Response("You can make submission only for your team", status=status.HTTP_400_BAD_REQUEST)
+            submission = Submission.objects.filter(
+                team=team, hackathon=hackathon)
+            if len(submission):
+                return Response("A Submission Already Exists!", status=status.HTTP_400_BAD_REQUEST)
 
         except Hackathon.DoesNotExist:
             raise exceptions.NotFound("Hackathon does not exist!")

--- a/core/views.py
+++ b/core/views.py
@@ -128,8 +128,10 @@ class HackathonsRUDView(generics.RetrieveUpdateDestroyAPIView):
 class HackathonSubmissionView(generics.ListCreateAPIView):
     """
     API used to get the list of all the submissions of particular hackathon.
+    and create submission for the hackathon
     """
     serializer_class = SubmissionsSerializer
+    permission_classes = [permissions.IsAuthenticatedOrReadOnly]
 
     def get_queryset(self, **kwargs):
         if getattr(self, 'swagger_fake_view', False):
@@ -148,6 +150,31 @@ class HackathonSubmissionView(generics.ListCreateAPIView):
             return queryset
         except Hackathon.DoesNotExist:
             raise exceptions.NotFound("Hackathon does not exist!")
+
+    def create(self, request, *args, **kwargs):
+        try:
+            hackathon = Hackathon.objects.get(id=self.kwargs['pk'])
+            # The default score should remain zero
+            # even if user has passed any other value
+            if 'score' in request.data:
+                request.data['score'] = 0
+            if hackathon.status != "Ongoing":
+                return Response("Submissions can only be made to Ongoing Hackathons", status=status.HTTP_400_BAD_REQUEST)
+            team = Team.objects.get(members=request.user, hackathon=hackathon)
+            if request.data['team'] != team.pk:
+                return Response("You can make submission only for your team", status=status.HTTP_400_BAD_REQUEST)
+
+        except Hackathon.DoesNotExist:
+            raise exceptions.NotFound("Hackathon does not exist!")
+        except Team.DoesNotExist:
+            raise exceptions.NotFound("Team does not exist!")
+
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
+
 
 class TeamView(generics.RetrieveUpdateDestroyAPIView):
     """

--- a/core/views.py
+++ b/core/views.py
@@ -127,7 +127,7 @@ class HackathonsRUDView(generics.RetrieveUpdateDestroyAPIView):
 
 class HackathonSubmissionView(generics.ListCreateAPIView):
     """
-    API used to get the list of all the submissions of particular hackathon.
+    API used to get the list of all the submissions of particular hackathon
     and create submission for the hackathon
     """
     serializer_class = SubmissionsSerializer
@@ -167,6 +167,7 @@ class HackathonSubmissionView(generics.ListCreateAPIView):
                 team=team, hackathon=hackathon)
             if len(submission):
                 return Response("A Submission Already Exists!", status=status.HTTP_400_BAD_REQUEST)
+            request.data['hackathon'] = self.kwargs['pk']
 
         except Hackathon.DoesNotExist:
             raise exceptions.NotFound("Hackathon does not exist!")


### PR DESCRIPTION
Fixes #15 

## Description 
Updated the `create()` method of `HackathonSubmissionView` to add validations for creation of submissions for a particular hackathon.
1. Added score validation (>= 0) to the `SubmissionsSerializer`.
2. Creation of submissions only to Ongoing hackathons and only for the user's team.
3. Reject request if submission for the same team under the same hackathon already exists.