### PR TITLE
Added UserStatus Field to Hackathon Serializer

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -104,7 +104,7 @@ class HackathonSerializer(serializers.ModelSerializer):
         '''
         request = self.context['request']
         if not request.auth:
-            return 'none'
+            return False
         teams = Team.objects.filter(members=request.user, hackathon=obj)
         submissions = []
         for team in teams:


### PR DESCRIPTION
## Description

Added a `SerializerMethodField` named `userStatus` field to the `HackathonSerializer` as required in the frontend. This field returns the following values about the status of the hackathon for the current user:
1. `False` if the user isn't logged in. 
2. `not registered` if the user hasn't participated in the hackathon
3. `registered` if the user has registered for the hackathon but hasn't submitted yet
4. `submitted` if the user has made at least one submission from one of their team.
- Details about the hackathon's status can be viewed in the `status` field of the response body.