### PR TITLE
Fixes #27

### DIFF
--- a/core/serializers.py
+++ b/core/serializers.py
@@ -80,7 +80,6 @@ class JoinTeamSerializer(serializers.Serializer):
 
 class HackathonSerializer(serializers.ModelSerializer):
     status = serializers.CharField()
-    userStatus = serializers.SerializerMethodField('get_userStatus')
 
     def validate_end(self, end):
         if end < timezone.now():
@@ -96,6 +95,13 @@ class HackathonSerializer(serializers.ModelSerializer):
         if attrs['start'] > attrs['end']:
             raise serializers.ValidationError('Event ends before starting')
         return attrs
+
+    class Meta:
+        model = Hackathon
+        fields = '__all__'
+
+class HackathonDetailSerializer(HackathonSerializer):
+    userStatus = serializers.SerializerMethodField('get_userStatus')
 
     def get_userStatus(self, obj):
         '''
@@ -116,10 +122,6 @@ class HackathonSerializer(serializers.ModelSerializer):
         elif not len(submissions):
             return 'registered'
         return 'submitted'
-
-    class Meta:
-        model = Hackathon
-        fields = '__all__'
 
 
 class SubmissionsSerializer(serializers.ModelSerializer):

--- a/core/views.py
+++ b/core/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import get_list_or_404
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
 from .models import Hackathon, Team, Submission
-from .serializers import HackathonSerializer, TeamSerializer, TeamCreateSerializer, JoinTeamSerializer, SubmissionsSerializer, MemberExitSerializer, SubmissionRUDSerializer
+from .serializers import HackathonSerializer, TeamSerializer, TeamCreateSerializer, JoinTeamSerializer, SubmissionsSerializer, MemberExitSerializer, SubmissionRUDSerializer,HackathonDetailSerializer
 from .permissions import HackathonPermissions, AllowCompleteProfile, IsLeaderOrSuperUser
 from authentication.serializers import ProfileSerializer
 
@@ -122,7 +122,7 @@ class HackathonsRUDView(generics.RetrieveUpdateDestroyAPIView):
     """
 
     permission_classes = [HackathonPermissions]
-    serializer_class = HackathonSerializer
+    serializer_class = HackathonDetailSerializer
     lookup_field = 'pk'
     queryset = Hackathon.objects.all()
 


### PR DESCRIPTION
## Description

1. Extended `HackathonSerializer` for making `HackathonDetailSerializer` with the old `userStatus` field to avoid context problems (happening in this issue)
2. Changed the serializer for `GET /hackathons/<id>`to `HackathonDetailSerializer`